### PR TITLE
Fix import of stand-alone XML files

### DIFF
--- a/brv/importer/dir.py
+++ b/brv/importer/dir.py
@@ -46,7 +46,7 @@ def load_data_with_prefix(xmlparser, path, prefix, xmls, bz2s, outputs, descr, a
 
 
     outfile = outputs[0] if outputs else None
-    total, toolrun_ids = load_xmls(xmlparser, xmls, outfile, descr,
+    total, toolrun_ids, _ = load_xmls(xmlparser, xmls, outfile, descr,
                       append_vers, allow_duplicates)
     print('Added {0} results'.format(total))
 

--- a/brv/importer/xml.py
+++ b/brv/importer/xml.py
@@ -10,5 +10,5 @@ def load_xmls(xmlparser, xmls, outputs = None, descr = None,
         total += cnt
         toolrun_ids.extend(run_ids)
 
-    return total, toolrun_ids
+    return total, toolrun_ids, outputs if outputs is not None else []
 


### PR DESCRIPTION
Fixes:
```
Traceback (most recent call last):
  File "./brv.py", line 83, in <module>
    perform_import(args)
  File "/home/x456487/mamato/brv/importer/importer.py", line 78, in perform_import
    total, toolrun_ids, outputs = importer(args)
ValueError: not enough values to unpack (expected 3, got 2)
```