### PR TITLE
Store category for each benchmark separately

### DIFF
--- a/brv/database/reader.py
+++ b/brv/database/reader.py
@@ -37,7 +37,7 @@ class DatabaseReader(DatabaseProxy):
         SELECT tool_run.id, tool.name, tool.version, date,
                options, cpulimit, memlimit,
                tool_run.description, tool_run.tags,
-               tool_run.outputs, tool_run.name
+               tool_run.outputs
         FROM tool JOIN tool_run ON tool.id = tool_id;
         """
         res = self.query(q)
@@ -53,7 +53,7 @@ class DatabaseReader(DatabaseProxy):
         SELECT tool_run.id, tool.name, tool.version, date,
                options, cpulimit, memlimit,
                tool_run.description, tool_run.tags,
-               tool_run.outputs, tool_run.name
+               tool_run.outputs
         FROM tool JOIN tool_run ON tool.id = tool_id
         WHERE tool_run.id = {0};
         """.format(rid)
@@ -106,11 +106,12 @@ class DatabaseReader(DatabaseProxy):
         # 5 -> exitcode
         # 6 -> property
         # 7 -> file name
+        # 8 -> prefix
 
         q = """
         SELECT status, cputime, walltime, memusage,
-               classification, exitcode, property, file
-        FROM run WHERE tool_run_id = '{0}' AND benchmarks_set_id = '{1}'; 
+               classification, exitcode, property, file, prefix
+        FROM run WHERE tool_run_id = '{0}' AND benchmarks_set_id = '{1}';
         """.format(tool_run_id, bset_id);
         print(q)
         # FIXME: use fetchone
@@ -132,10 +133,11 @@ class DatabaseReader(DatabaseProxy):
         # 5 -> exitcode
         # 6 -> property
         # 7 -> file name
+        # 8 -> prefix
 
         q = """
         SELECT status, cputime, walltime, memusage,
-               classification, exitcode, property, file
+               classification, exitcode, property, file, prefix
         FROM run WHERE tool_run_id = '{0}'
         ORDER BY file ASC;
         """.format(tool_run_id);

--- a/brv/database/writer.py
+++ b/brv/database/writer.py
@@ -81,14 +81,14 @@ class DatabaseWriter(DatabaseProxy):
             q = """
             INSERT INTO tool_run
               (tool_id, options, memlimit, cpulimit, date,
-               description, name, outputs)
-              VALUES ('{0}', '{1}', '{2}', '{3}', '{4}', '{5}', '{6}', {7});
+               description, outputs)
+              VALUES ('{0}', '{1}', '{2}', '{3}', '{4}', '{5}', {6});
             """.format(tool_id, toolinfo.options,
                        toolinfo.memlimit, toolinfo.timelimit,
                        toolinfo.date,
                        None2Empty(toolinfo.benchmarkname) + ":" +
                        None2Empty(toolinfo.description),
-                       toolinfo.name, None2Null(outputs))
+                       None2Null(outputs))
             self.query_noresult(q)
             tool_run_id = self.queryInt("SELECT LAST_INSERT_ID();")
 
@@ -116,15 +116,16 @@ class DatabaseWriter(DatabaseProxy):
         q = """
         INSERT INTO run
         (status, cputime, walltime, memusage, classification, exitcode, exitsignal,
-         terminationreason, tool_run_id, benchmarks_set_id, property, options, file)
+         terminationreason, tool_run_id, benchmarks_set_id, property, options,
+         file, prefix)
         VALUES ('{0}', {1}, {2}, {3}, '{4}', {5}, '{6}', '{7}', '{8}', '{9}',
-        '{10}', '{11}', '{12}');
+        '{10}', '{11}', '{12}', '{13}');
         """.format(runinfo.status(), None2Null(runinfo.cputime()), None2Null(runinfo.walltime()),
                    None2Null(runinfo.memusage()), runinfo.classification(), None2Null(runinfo.exitcode()),
                    0, 0, #FIXME
                    tool_run_id, benchmarks_set_id,
                    runinfo.property(), None, #FIXME
-                   runinfo.fullname())
+                   runinfo.fullname(), runinfo.prefix())
                     #FIXME: what return value?
         self.query_noresult(q)
 

--- a/brv/runinfo.py
+++ b/brv/runinfo.py
@@ -38,6 +38,9 @@ class RunInfo(object):
     def property(self):
         raise NotImplemented
 
+    def prefix(self):
+        raise NotImplemented
+
     def dump(self):
         print(' -- Result --')
         print('  {0} ({1})'.format(self.name(), self.fullname()))
@@ -69,6 +72,7 @@ class DBRunInfo(RunInfo):
     # 5 -> exitcode
     # 6 -> property
     # 7 -> file name
+    # 8 -> prefix
 
     def status(self):
         return self._query_result[0]
@@ -94,6 +98,9 @@ class DBRunInfo(RunInfo):
     def fullname(self):
         return self._query_result[7]
 
+    def prefix(self):
+        return self._query_result[8]
+
 
 class DirectRunInfo(RunInfo):
     """
@@ -114,6 +121,7 @@ class DirectRunInfo(RunInfo):
         self._property = None
         self._exitcode = None
         self._returnvalue = None
+        self._prefix = None
         # other attributes
         #self.others = {}
 
@@ -122,6 +130,9 @@ class DirectRunInfo(RunInfo):
 
     def fullname(self):
         return self._fullname
+
+    def prefix(self):
+        return self._prefix
 
     def status(self):
         return self._status

--- a/brv/server/showfiles.py
+++ b/brv/server/showfiles.py
@@ -151,11 +151,9 @@ def showFiles(wfile, datamanager, opts):
     if results:
         assert len(runs) == len(results[0][1])
     outputs = [None2Empty(r.outputs()) for r in runs]
-    run_names = [None2Empty(r.name()) for r in runs]
     render_template(wfile, 'files.html',
                      {'runs' : runs,
                       'outputs' : outputs,
-                      'run_names' : run_names,
                       'get' : get_elem,
                       'getBenchmarkURL' : getBenchmarkURL,
                       'getShortName' : getShortName,

--- a/brv/server/showfilter.py
+++ b/brv/server/showfilter.py
@@ -169,12 +169,9 @@ def showFilter(wfile, datamanager, opts):
             output_tables.append((bset, results))
 
     outputs = [None2Empty(r.outputs()) for r in runs]
-    run_names = [None2Empty(r.name()) for r in runs]
-
     render_template(wfile, 'filter.html',
                      {'runs' : runs,
                       'outputs' : outputs,
-                      'run_names' : run_names,
                       'get' : get_elem,
                       'getBenchmarkURL' : getBenchmarkURL,
                       'getShortName' : getShortName,

--- a/brv/server/showoverall.py
+++ b/brv/server/showoverall.py
@@ -137,11 +137,9 @@ def showOverall(wfile, datamanager, opts):
             output_tables.append((bset, results))
 
     outputs = [None2Empty(r.outputs()) for r in runs]
-    run_names = [None2Empty(r.name()) for r in runs]
     render_template(wfile, 'filter.html',
                      {'runs' : runs,
                       'outputs' : outputs,
-                      'run_names' : run_names,
                       'get' : get_elem,
                       'getBenchmarkURL' : getBenchmarkURL,
                       'getShortName' : getShortName,

--- a/brv/toolrun.py
+++ b/brv/toolrun.py
@@ -38,9 +38,6 @@ class ToolRun(object):
     def outputs(self):
         raise NotImplemented
 
-    def name(self):
-        raise NotImplemented
-
     def getResults(self):
         return self._runs
 
@@ -48,7 +45,7 @@ class ToolRun(object):
         return self._stats
 
     def getLimits(self):
-        return timelimit() + ' ' + memlimit()
+        return self.timelimit() + ' ' + self.memlimit()
 
     def addRun(self, r):
         """
@@ -87,9 +84,6 @@ class DBToolRun(ToolRun):
 
     def outputs(self):
         return self._query_result[9]
-
-    def name(self):
-        return self._query_result[10]
 
 def sum_elems(lhs, rhs):
     "Sum elements in tuples pair-wise"

--- a/brv/xml/parser.py
+++ b/brv/xml/parser.py
@@ -113,6 +113,7 @@ class XMLParser(object):
 
         for run in xmlfl.getElementsByTagName('run'):
             r = _parse_run_elem(run)
+            r._prefix = ret.name;
             ret.append(r)
 
         return ret
@@ -145,6 +146,7 @@ class XMLParser(object):
         cnt = 0;
         for run in xmlfl.getElementsByTagName('run'):
             r = _parse_run_elem(run)
+            r._prefix = tool_info.name;
             writer.writeRunInfo(tool_run_id, benchmarks_set_id, r)
             cnt += 1
 

--- a/database_scheme.sql
+++ b/database_scheme.sql
@@ -21,7 +21,6 @@ CREATE TABLE `tool_run` (
   `description` VARCHAR(255) DEFAULT NULL,
   `tags` TEXT DEFAULT NULL,
   `outputs` VARCHAR(512) DEFAULT NULL,
-  `name` VARCHAR(255) DEFAULT NULL,
   PRIMARY KEY (`id`),
   FOREIGN KEY (`tool_id`) REFERENCES `tool` (`id`)
 );
@@ -38,6 +37,7 @@ CREATE TABLE `run` (
   `tool_run_id` int(11) NOT NULL,
   `benchmarks_set_id` int(11) NOT NULL,
   `property` varchar(100) DEFAULT NULL,
+  `prefix` varchar(255) DEFAULT NULL,
   `options` text,
   `file` text,
   FOREIGN KEY (`tool_run_id`) REFERENCES `tool_run` (`id`),

--- a/html/templates/files.html
+++ b/html/templates/files.html
@@ -266,7 +266,7 @@ function showOutput(archive, run_name, name) {
     #for @runinfo in @get(@result, 1):
       <td>
       <span class="status status-@runinfo.classification()"
-            onclick="showOutput('@get(@outputs, @n)', '@get(@run_names, @n)', '@shortname')">
+            onclick="showOutput('@get(@outputs, @n)', '@runinfo.prefix()', '@shortname')">
       #if(@runinfo)
       @runinfo.status()
       #else

--- a/html/templates/filter.html
+++ b/html/templates/filter.html
@@ -262,7 +262,7 @@ function showOutput(archive, run_name, name) {
     #for @runinfo in @get(@result, 1):
       <td>
       <span class="status status-@runinfo.classification()"
-            onclick="showOutput('@get(@outputs, @n)', '@get(@run_names, @n)', '@shortname')">
+            onclick="showOutput('@get(@outputs, @n)', '@runinfo.prefix()', '@shortname')">
       #if(@runinfo)
       @runinfo.status()
       #else


### PR DESCRIPTION
Previously, only one category was stored for the *whole* test run.

Not a particularly efficient solution due to added redundancy, but it does the job.

Fixes issue when a log for different category was tried to be opened (e.g. `no-overflow` for `unreach-call` benchmark):
```
"There is no item named 'archive/SV-COMP22_no-overflow.test.yml.log' in the archive"
```
when the file prefix should have been `SV-COMP22_unreach-call` instead.